### PR TITLE
Fix time of by one errors (daylight savings)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     "log": false,
     "gaSendEvent": false,
     "gaLogException": false,
+    "helpers": true,
     "Widget": false,
     "WidgetNew": false,
     "Sport": false,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ const jsfiles = [
   // 'source/js/*.js'
   'source/js/handlebars-helpers.js',
   'source/js/browser.js',
+  'source/js/dataFetchers/helpers.js',
   'source/js/dataFetchers/NHLData.js',
   'source/js/dataFetchers/NFLData.js',
   'source/js/dataFetchers/MLBData.js',

--- a/source/js/dataFetchers/MLBData.js
+++ b/source/js/dataFetchers/MLBData.js
@@ -90,8 +90,7 @@ const MLBData = { // eslint-disable-line no-unused-vars
               hours -= 12;
             }
 
-            const EST_UTC_OFFSET = 5; // EST + 5 = UTC
-            date.setUTCHours((hours + EST_UTC_OFFSET) % 24, minutes);
+            date.setUTCHours((hours + helpers.etUtcOffset()) % 24, minutes);
             timeToShow = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
           } catch (e) {
             timeToShow = `${game.time} ${game.time_zone}`;

--- a/source/js/dataFetchers/NBAData.js
+++ b/source/js/dataFetchers/NBAData.js
@@ -58,9 +58,7 @@ const NBAData = { // eslint-disable-line no-unused-vars
 
           const date = new Date(yyyy, mm, dd);
 
-          const EST_UTC_OFFSET = 5 - 1; // EST + 5 = UTC
-
-          date.setUTCHours((hours + EST_UTC_OFFSET) % 24, minutes);
+          date.setUTCHours((hours + helpers.etUtcOffset()) % 24, minutes);
           const gametime = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
           game.period_time.period_status = gametime;
         }

--- a/source/js/dataFetchers/helpers.js
+++ b/source/js/dataFetchers/helpers.js
@@ -1,0 +1,31 @@
+const helpers = {}; // eslint-disable-line no-unused-vars
+
+/**
+ * Calculates offset between [US East Coast (EST or EDT)] and [UTC]
+ *
+ * To determine if the US East coast is in either
+ * EST (Eastern Standard Time) or EDT (Eastern Daylight Savings Time)
+ * the function first determines if day light savings time is on
+ *
+ * https://stackoverflow.com/questions/11887934/how-to-check-if-the-dst-daylight-saving-time-is-in-effect-and-if-it-is-whats
+ * https://www.timeanddate.com/time/zones/est
+ * https://www.timeanddate.com/time/zones/edt
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset
+ *
+ * @param {Date} [date=(new Date())] - date on which to calculate offset
+ * @returns {number} offset (4 or 5)
+ *
+ */
+helpers.etUtcOffset = (date = new Date()) => {
+  const jan = new Date(date.getFullYear(), 0, 1);
+  const jul = new Date(date.getFullYear(), 6, 1);
+
+  const stdTimezoneOffset = Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
+  const dalightSavingsTime = date.getTimezoneOffset() < stdTimezoneOffset;
+
+  // EST + 5 = UTC
+  // EDT + 5 = UTC
+  const EST_UTC_OFFSET = 5;
+  const EDT_UTC_OFFSET = 4;
+  return dalightSavingsTime ? EDT_UTC_OFFSET : EST_UTC_OFFSET;
+};


### PR DESCRIPTION
fixes time for MLB (and creates a long term fix for NBA)

NHL does not need fix (api returns dates in `utc`  🍾 )

TODO: 
 * take `toLocalTime` logic out from each data fetcher, and put into `helpers`
 * figure out if NFL is right, and fix if not (refactor should help) 