### PR TITLE
Use Pacific Time to show games of the day for sports

### DIFF
--- a/source/js/dataFetchers/helpers.js
+++ b/source/js/dataFetchers/helpers.js
@@ -1,33 +1,41 @@
 const helpers = {}; // eslint-disable-line no-unused-vars
 
 /**
- * Calculates offset between [US East Coast (EST or EDT)] and [UTC]
- *
- * To determine if the US East coast is in either
- * EST (Eastern Standard Time) or EDT (Eastern Daylight Savings Time)
- * the function first determines if day light savings time is on
+ * @param {Date} [date=(new Date())] - date on which to determine if DST is on
+ * @returns {boolean} isDaylightSavingsOn
  *
  * https://stackoverflow.com/questions/11887934/how-to-check-if-the-dst-daylight-saving-time-is-in-effect-and-if-it-is-whats
- * https://www.timeanddate.com/time/zones/est
- * https://www.timeanddate.com/time/zones/edt
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset
- *
- * @param {Date} [date=(new Date())] - date on which to calculate offset
- * @returns {number} offset (4 or 5)
- *
  */
-const etUtcOffset = (date = new Date()) => {
+const isDaylightSavingsTimeOn = (date = new Date()) => {
   const jan = new Date(date.getFullYear(), 0, 1);
   const jul = new Date(date.getFullYear(), 6, 1);
 
   const stdTimezoneOffset = Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
   const dalightSavingsTime = date.getTimezoneOffset() < stdTimezoneOffset;
 
+  return dalightSavingsTime;
+};
+
+/**
+ * Calculates offset between [US East Coast (EST or EDT)] and [UTC]
+ *
+ * To determine if the US East coast is in either
+ * EST (Eastern Standard Time) or EDT (Eastern Daylight Savings Time)
+ * the function first determines if day light savings time is on
+ *
+ * https://www.timeanddate.com/time/zones/est
+ * https://www.timeanddate.com/time/zones/edt
+ *
+ * @param {Date} [date=(new Date())] - date on which to calculate offset
+ * @returns {number} offset (4 or 5)
+ */
+const etUtcOffset = (date = new Date()) => {
   // EST + 5 = UTC
   // EDT + 4 = UTC
   const EST_UTC_OFFSET = 5;
   const EDT_UTC_OFFSET = 4;
-  return dalightSavingsTime ? EDT_UTC_OFFSET : EST_UTC_OFFSET;
+  return isDaylightSavingsTimeOn(date) ? EDT_UTC_OFFSET : EST_UTC_OFFSET;
 };
 
 const etToUTC = (date) => {

--- a/source/js/dataFetchers/helpers.js
+++ b/source/js/dataFetchers/helpers.js
@@ -43,6 +43,24 @@ const etToUTC = (date) => {
   return date;
 };
 
+const pacificTimeUTCOffset = (date = new Date()) => {
+  // PST -8 = UTC // PDT -7 = UTC
+  const PDT_UTC_OFFSET = -7; const PST_UTC_OFFSET = -8;
+  return isDaylightSavingsTimeOn(date) ? PDT_UTC_OFFSET : PST_UTC_OFFSET;
+};
+
+/**
+ * https://stackoverflow.com/a/9070729
+ *
+ * @param {Date} clientDate
+ * @returns {Date} dateInPT
+ */
+helpers.dateInPT = (clientDate = new Date()) => {
+  const utc = clientDate.getTime() + (clientDate.getTimezoneOffset() * 60000);
+  const pacificTime = new Date(utc + (3600000 * pacificTimeUTCOffset(clientDate)));
+  return pacificTime;
+};
+
 /**
  * Convert date in EST/EDT or UTC to user (current system) local time
  * @param {Date} date

--- a/source/js/dataFetchers/helpers.js
+++ b/source/js/dataFetchers/helpers.js
@@ -24,7 +24,7 @@ const etUtcOffset = (date = new Date()) => {
   const dalightSavingsTime = date.getTimezoneOffset() < stdTimezoneOffset;
 
   // EST + 5 = UTC
-  // EDT + 5 = UTC
+  // EDT + 4 = UTC
   const EST_UTC_OFFSET = 5;
   const EDT_UTC_OFFSET = 4;
   return dalightSavingsTime ? EDT_UTC_OFFSET : EST_UTC_OFFSET;

--- a/source/js/sport.js
+++ b/source/js/sport.js
@@ -2,7 +2,7 @@ class Sport extends WidgetNew { // eslint-disable-line no-unused-vars
 
   constructor() {
     super();
-    this.today = new Date();
+    this.today = helpers.dateInPT(new Date());
   }
 
   init() {


### PR DESCRIPTION
Want to show the currently playing/active games. Pacific Time is where the latest games are played.

Don't want to switch games prematurely in other time zones (e.g. the day changes earlier on the East Coast / Europe, so the extension shows the next day games even when there are still on-going games for the previous day).

Fixes #28 